### PR TITLE
Fixing reflecting changes without page reload

### DIFF
--- a/ui/src/app/shared/components/price-list/price-list.component.ts
+++ b/ui/src/app/shared/components/price-list/price-list.component.ts
@@ -236,27 +236,27 @@ export class PriceListComponent implements OnInit, OnChanges {
     };
   }
 
-  onSaveItem(itemPrice): void {
-    this.pricingService.saveItemPrice(itemPrice).subscribe((response) => {
-      if (response && !response?.error) {
-        console.log('Price saved successfully');
-  
-        // Find the item in the local data and update it
-        const index = this.priceList.findIndex(
-          (item) => item.uuid === itemPrice.uuid
-        );
-        if (index > -1) {
-          // Update the specific item
-          this.priceList[index] = { ...this.priceList[index], ...response };
-        } else {
-          // If not found, optionally add it to the list (for new entries)
-          this.priceList = [...this.priceList, response];
-        }
+   onSaveItem(itemPrice): void {
+  this.pricingService.saveItemPrice(itemPrice).subscribe((response) => {
+    if (response && !response?.error) {
+      console.log('Price saved successfully');
+
+      // Find the item in the local data and update it
+      const index = this.priceList.findIndex(
+        (item) => item.uuid === itemPrice.uuid
+      );
+      if (index > -1) {
+        // Update the specific item
+        this.priceList[index] = { ...this.priceList[index], ...response };
       } else {
-        console.error('Error saving item price:', response);
+        // If not found, optionally add it to the list (for new entries)
+        this.priceList = [...this.priceList, response];
       }
-    });
-  }
+    } else {
+      console.error('Error saving item price:', response);
+    }
+  });
+}
 
   onFormUpdate(
     formValue: FormValue,


### PR DESCRIPTION
Fix bug: A system should pick changes of the prices immediately after edit instead waiting to refresh page

How we fixed it:
we find where the method responsible to save the changes that called onSaveItem() method that found inside price-list.component.ts, we modified in such a way that it reflect the changes both in console and on the webpage without reload

Members

SIMON SELELI 2022-04-12519
IBRAHIM MBWATE 2022-04-07053
RAMADHANI BOKWA 2022-04-00838
KEFLINE MADUHU 2022-04-04118
EPHRANCINA EMILLY 2022-04-00782